### PR TITLE
Changed the file checksum from MD5 to SHA512

### DIFF
--- a/cyg-fast
+++ b/cyg-fast
@@ -624,13 +624,13 @@ function cyg-fast-resume-install()
       file="$(basename "$install")"
       cd "release/$pkg"
       
-      # check the md5
+      # check the sha512
 
       while true; do
         local digest="$(awk '/^install: / { print $4; exit }' "desc")"
-        local digactual="$(md5sum $file | awk '{print $1}')"
+        local digactual="$(sha512sum $file | awk '{print $1}')"
         if [ "$digest" != "$digactual" ]; then
-          error "MD5 sum did not match, retry downloading..."
+          error "SHA512 sum did not match, retry downloading..."
           aria2c $mirror/$install
         else break; fi
       done


### PR DESCRIPTION
This pull request is to follow the change of the file checksum in the original Cygwin.

See below for the details:
https://cygwin.com/ml/cygwin-announce/2015-02/msg00013.html
https://github.com/transcode-open/apt-cyg/issues/37

BTW in my opinion, the `while` loop around check sum should have maximum number of iterations, otherwise broken files may cause infinite loop.
This also makes the cache too large, because the aria2 repeatedly makes renamed copies (this can be avoided by adding `--allow-overwrite=true` option)
